### PR TITLE
Removes css which overrides govuk css

### DIFF
--- a/app/static/css/_global.css
+++ b/app/static/css/_global.css
@@ -49,10 +49,6 @@ a:hover {
     background-color: var(--apha-green);
 }
 
-.govuk-button--secondary {
-    background-color: #f3f2f1;;
-}
-
 .warning-text {
     color: var(--apha-orange);
     font-size: 20px;

--- a/app/static/js/snpdistance.js
+++ b/app/static/js/snpdistance.js
@@ -982,7 +982,7 @@ const showRelatedSamples = async function () {
             <span>OS Map Reference: ${json[soi].os_map_ref}<br/></span>
             <span>Clade: ${json[soi].clade}<br/></span>
           </p>
-          <button id="btn-download-snptable" class="govuk-button govuk-button--secondary btn-snptable" onclick="downloadSNPTable()">Download CSV</button>
+          <button id="btn-download-snptable" class="govuk-button btn-snptable" onclick="downloadSNPTable()">Download CSV</button>
         `);
 
         // Tabulator requires array of json objects


### PR DESCRIPTION
This PR fixes the issue raised in PR #142, where the 'Download CSV' button in the snp map was causing poor accessibility as shown in this image:
![image](https://github.com/APHA-CSU/ViewBovis/assets/125119407/68c96e70-001e-4e87-a1c3-814eb1357179)
 
By removing the css which was causing the issue, the fix can be shown below:

![image](https://github.com/APHA-CSU/ViewBovis/assets/125119407/6accc2d8-60fa-4666-8186-1008ff030d16)

