### PR TITLE
Update dependency versions to address dependabot alerts

### DIFF
--- a/app/front_end/package-lock.json
+++ b/app/front_end/package-lock.json
@@ -9661,8 +9661,8 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
       "integrity": "sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -18295,7 +18295,7 @@
         "express": "^4.17.3",
         "graceful-fs": "^4.2.6",
         "html-entities": "^2.3.2",
-        "http-proxy-middleware": "^2.0.3",
+        "http-proxy-middleware": "^2.0.7",
         "ipaddr.js": "^2.0.1",
         "launch-editor": "^2.6.0",
         "open": "^8.0.9",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 flask==2.2.5
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 pandas==1.5.3
 gunicorn==23.0.0
 requests==2.32.0


### PR DESCRIPTION
Dependabot has raised security alerts which can be fixed by updating versions of `http-proxy-middleware` and `Werkzeug`